### PR TITLE
bugfix: 修复在多层ViewGroup嵌套场景下，无法获取到子 View 的情况

### DIFF
--- a/uetool/src/main/java/me/ele/uetool/CollectViewsLayout.java
+++ b/uetool/src/main/java/me/ele/uetool/CollectViewsLayout.java
@@ -140,12 +140,14 @@ public class CollectViewsLayout extends View {
         if (UETool.getInstance().getFilterClasses().contains(view.getClass().getName())) return;
         if (view.getAlpha() == 0 || view.getVisibility() != View.VISIBLE) return;
         if (getResources().getString(R.string.uet_disable).equals(view.getTag())) return;
-        elements.add(new Element(view));
         if (view instanceof ViewGroup) {
+            elements.add(0, new Element(view));
             ViewGroup parent = (ViewGroup) view;
             for (int i = 0; i < parent.getChildCount(); i++) {
                 traverse(parent.getChildAt(i));
             }
+        } else {
+            elements.add(new Element(view));
         }
     }
 


### PR DESCRIPTION
## 问题描述
在”捕获控件” 模式下，用户点击有可能只能获取到父 ViewGroup，而实际上用户的意图是想点击其中的子
View，该场景多出现于多层ViewGroup 嵌套的视图中。
## 解决方案
在 traverse 遍历 View 树添加到 elements 中时，将ViewGroup 添加到前面，View 添加到后面。这样在 getTargetElement 查找被点击坐标所对应的 控件 时会先查找 View 再查找ViewGroup，这样不会因为ViewGroup的“遮挡”而无法获取其子View。