### PR TITLE
bug:修复在部分场景下重复点击无法找到View的情况

### DIFF
--- a/uetool/src/main/java/me/ele/uetool/CollectViewsLayout.java
+++ b/uetool/src/main/java/me/ele/uetool/CollectViewsLayout.java
@@ -181,7 +181,7 @@ public class CollectViewsLayout extends View {
                 } else if (parentElement != null) {
                     parentElement = parentElement.getParentElement();
                 }
-                target = parentElement;
+                target = parentElement == null ? element : parentElement;
                 break;
             }
         }


### PR DESCRIPTION
## 问题描述
不是很好描述...  就是在有些地方第一次点击的时候View是可以找到View的，第二次再点就提示找不到了。问题出在 getTargetElement 这个方法中，满足以下两个条件会复现：
1. element 合 childElement 相同 (因为上一次点击导致的，属性编辑dialog dismiss 后 targetElement会置空但是 childElement 并不会)
2. parentElement 不为空但是  parentElement.getParentElement() 为空
这就导致最后 target 为 空
## 解决方案
最后对 parentElement 进行判空
```target = parentElement == null ? element : parentElement;```